### PR TITLE
test that shows the code fails to compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+cmake-build-debug/
+cmake-build-release/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-.idea/
-cmake-build-debug/
-cmake-build-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(structarch)
+cmake_minimum_required(VERSION 3.9)
+enable_testing()
+
+add_executable(tree_tests tests/tree_tests.cpp)
+
+set_property(TARGET tree_tests PROPERTY CXX_STANDARD 17)
+
+add_test(tree-tests tree_tests)
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,3 @@ add_executable(tree_tests tests/tree_tests.cpp)
 set_property(TARGET tree_tests PROPERTY CXX_STANDARD 17)
 
 add_test(tree-tests tree_tests)
-
-

--- a/include/tree/tree_iterator.hpp
+++ b/include/tree/tree_iterator.hpp
@@ -50,13 +50,13 @@ namespace rzd {
 		iterator& operator--()
 		{
 			if (is_end)
-				leaf = tree_ref.rightmost();
+				leaf = tree_ref.rightmost(tree_ref.root);
 			else if (leaf == nullptr)
 				throw std::out_of_range("iterator went wrong way");
 			else if (leaf->left != nullptr)
 				leaf = tree_ref.rightmost(leaf->left);
 			else
-				leaf = prev_parent(value);
+				leaf = prev_parent(leaf);
 			is_end = false;
 			return *this;
 		}

--- a/tests/tree_tests.cpp
+++ b/tests/tree_tests.cpp
@@ -1,0 +1,8 @@
+#include "../include/tree/tree.hpp"
+
+int main()
+{
+    rzd::tree<int, int> t;
+    t[1] = 1;
+
+}

--- a/tests/tree_tests.cpp
+++ b/tests/tree_tests.cpp
@@ -1,8 +1,24 @@
 #include "../include/tree/tree.hpp"
+#include <cassert>
 
 int main()
 {
-    rzd::tree<int, int> t;
-    t[1] = 1;
+	rzd::tree<int, char> tree{ { 0, 'a' }, { 2, 'b' }, { -2, 'c' } };
+	tree[-1] = 'd';
+	tree[-3] = 'e';
+	tree[3] = 'f';
 
+	assert((*tree.insert({ 1, 'g' })).second == 'g');
+	assert(tree.erase(0) == true);
+	assert(tree.erase(0) == false);
+	assert((*tree.begin()).second == 'e');
+	assert((*--tree.end()).second == 'f');
+	assert((*tree.find(2)).second == 'b');
+	assert(tree.erase(tree.find(-1)) == true);
+	assert(tree.empty() == false);
+
+	tree.clear();
+
+	assert(tree.empty() == true);
+	assert(tree.begin() == tree.end());
 }


### PR DESCRIPTION
There is a problem inside of predecrement of the iterator (`value` doesn't exist in this scope). I've manually tried to track it, but indeed there is no such name declared. There might be other problems hiding. Absence of tests will make the base of the project unstable. Eventually number of bugs might overwhelm.

I've written cmake script to test it, but it uses the newest one (3.9) directly from the repository. The test file is also simple, and only demonstrates a compilation error. Adding behavior test would be great as well.